### PR TITLE
Communicate with python

### DIFF
--- a/sound/sound_test.py
+++ b/sound/sound_test.py
@@ -15,8 +15,8 @@ pygame.mixer.init(44100, -16, channels=2, buffer=4096 )
 channel1 = pygame.mixer.Channel(0) # argument must be int
 channel2 = pygame.mixer.Channel(1)
 
-sound1 = pygame.mixer.Sound("Casio-MT-45-16-Beat.wav")
-sound2 = pygame.mixer.Sound("Kawai-K3-Electric-Piano-C4.wav")
+sound1 = pygame.mixer.Sound("./sound/Casio-MT-45-16-Beat.wav")
+sound2 = pygame.mixer.Sound("./sound/Kawai-K3-Electric-Piano-C4.wav")
 
 # plays loop of rain sound indefinitely until stopping playback on Channel,
 # interruption by another Sound on same Channel, or quitting pygame
@@ -29,21 +29,21 @@ down = True
 while True: # infinite while-loop
 	# play thunder sound if random condition met
 
-	i = c.recv(2) # receives sensor value from the socket
-	print i
+	i = c.recv(4096) # receives sensor value from the socket
+	print(i)
 
-	if i > 100:
-		channel2.play(sound2)
-		channel2.set_volume(random.random(),random.random())
-		print('My duration', duration)
-		time.sleep(duration)
+	# if i > 100:
+	# 	channel2.play(sound2)
+	# 	channel2.set_volume(random.random(),random.random())
+	# 	print('My duration', duration)
+	# 	time.sleep(duration)
 		
-	time.sleep(0.1)	
-	if down:
-		sound1.set_volume(sound1.get_volume() - 0.01)
-		if sound1.get_volume() <= 0.5:
-			down = False
-	else:
-		sound1.set_volume(sound1.get_volume() + 0.01)
-		if sound1.get_volume() >= 1:
-			down = True
+	# time.sleep(0.1)	
+	# if down:
+	# 	sound1.set_volume(sound1.get_volume() - 0.01)
+	# 	if sound1.get_volume() <= 0.5:
+	# 		down = False
+	# else:
+	# 	sound1.set_volume(sound1.get_volume() + 0.01)
+	# 	if sound1.get_volume() >= 1:
+	# 		down = True

--- a/web/lib/classes/realSensor.js
+++ b/web/lib/classes/realSensor.js
@@ -4,13 +4,22 @@ import Readline from '@serialport/parser-readline'
 export class RealSensor {
     constructor(arduinoConfig) {
         this.tension = Math.max(arduinoConfig.baseTension, 0)
+        this.fastSensorSpeed = 0
+        this.slowSensorSpeed = 0
         this.oldTension = [this.tension, this.tension, this.tension, this.tension]
         this.sensorPosition = arduinoConfig.sensors[0].position
         this.column = arduinoConfig.column
-        const portName = arduinoConfig.name
+        this.key = arduinoConfig.name
+        this.baudRate = arduinoConfig.baudRate
+
+        this.init()
+    }
+
+    init() {
+        const portName = this.key
 
         this.port = new SerialPort(`${portName}`, {
-            baudRate: arduinoConfig.baudRate
+            baudRate: this.baudRate
         })
 
         this.parser = this.port.pipe(new Readline({ delimiter: '\n' }))
@@ -24,7 +33,10 @@ export class RealSensor {
         })
     }
 
-    update(tension) {
+    update(sensorData) {
+        const tension = sensorData.fast
+        this.fastSensorSpeed = Math.max(sensorData.fast, 0)
+        this.slowSensorSpeed = Math.max(sensorData.slow, 0)
         if (!tension) return
         for (let key = 0; key < 4; key++) {
             this.oldTension[key] = (this.oldTension[key])

--- a/web/lib/helpers/communicateWithPython.js
+++ b/web/lib/helpers/communicateWithPython.js
@@ -1,0 +1,15 @@
+import net from 'net'
+
+const pythonClient = net.createConnection({ port: 8124 }).on('error', () => {
+    console.log('python disconnected')
+})
+
+export const writeToPython = (sensorsData, currentMode) => {
+    const toPython = sensorsData.map(sensor => ({
+        name: sensor.key,
+        slow: sensor.slowSensorSpeed,
+        fast: sensor.fastSensorSpeed
+    }))
+    toPython.mode = currentMode
+    pythonClient.write(JSON.stringify(toPython))
+}

--- a/web/lib/helpers/dataHelpers.js
+++ b/web/lib/helpers/dataHelpers.js
@@ -90,10 +90,22 @@ const regroupConfig = (ledsConfig) => {
     return regroupedConfig
 }
 
+const getInfoFromSensors = (data) => {
+    const received = data.split('\t')
+
+    if (received && received.length > 2) {
+        return {
+            fast: received[0].split('! ')[1],
+            slow: received[1]
+        }
+    }
+}
+
 export {
     addColor,
     combineLEDs,
     regroupConfig,
     putLedsInBufferArray,
+    getInfoFromSensors,
     eliminateLEDsConfigRepetition
 }

--- a/web/server.js
+++ b/web/server.js
@@ -3,12 +3,14 @@
 import modes from './lib/visualisations'
 import {
 	putLedsInBufferArray,
-	regroupConfig
+	regroupConfig,
+	getInfoFromSensors
 } from './lib/helpers/dataHelpers'
-import { connectToArduinos } from './lib/helpers/connectToArduinos.js'
-import { spinServer } from './lib/helpers/spinServer.js'
-import { NUMBER_OF_LEDS } from './lib/configuration/constants.js'
+import { connectToArduinos } from './lib/helpers/connectToArduinos'
+import { spinServer } from './lib/helpers/spinServer'
+import { NUMBER_OF_LEDS } from './lib/configuration/constants'
 import earConfig from './lib/helpers/config'
+import { writeToPython } from './lib/helpers/communicateWithPython';
 
 const connectedSockets = {}
 const clientConfigurations = earConfig.read()
@@ -33,7 +35,7 @@ const realSticks = [ // TODO move to some config
 ]
 
 const calculateDataForRealLeds = (data, realSensor) => { // TO BE CHANGED WHEN HAVE ACCESS TO HARDWARE
-	const sensorData = parseFloat(data.split('\t')[0].split('! ')[1])
+	const sensorData = getInfoFromSensors(data)
 	realSensor.update(sensorData)
 
 	realSensorsData = realSensors.map(sensor => ({
@@ -46,6 +48,8 @@ const calculateDataForRealLeds = (data, realSensor) => { // TO BE CHANGED WHEN H
 	let combinedSensors = [...clientSensors, ...realSensors]
 	const ledsConfigFromClient = currentMode(realSticks, combinedSensors).filter(Boolean)
 	ledsConfig = regroupConfig(ledsConfigFromClient)
+
+	writeToPython(combinedSensors, currentMode)
 
 	return putLedsInBufferArray(ledsConfig[0].leds, NUMBER_OF_LEDS)
 }
@@ -92,10 +96,12 @@ io.on('connection', socket => {
 		}
 
 		clientSensors = sensors
-		const sensorToPass = realSensorsData && realSensorsData.length > 0 ? [...clientSensors, ...realSensorsData] : clientSensors
-		const ledsConfigFromClient = currentMode(sticks, sensorToPass).filter(Boolean)
+		const sensorsToPass = realSensorsData && realSensorsData.length > 0 ? [...clientSensors, ...realSensorsData] : clientSensors
+		const ledsConfigFromClient = currentMode(sticks, sensorsToPass).filter(Boolean)
 		ledsConfig = regroupConfig(ledsConfigFromClient)
 		socket.emit('ledsChanged', ledsConfig)
+
+		writeToPython(sensorsToPass, currentMode)
 		// ledsConfigFromClient.map(ledConfig => socket.emit('ledsChanged', ledConfig)) // keep for now for development processes
 	})
 


### PR DESCRIPTION
Uses `net` from the node side and `socket` in Python, using port `8124`.
Writes a string with the required data. Python reads string (this can be changed to Buffer or Unit8Array if necessary).

Currently it sends string like this:
```
b'[{"name":"a","slow":0.01,"fast":0.1},{"name":"s","slow":0.01,"fast":0.1},{"name":"/dev/tty.usbmodem14201","slow":2.71,"fast":2.68},{"name":"COM14","slow":0,"fast":0}]'
```